### PR TITLE
bugfix for error:getHiddenFiles() must be of the type bool, null returned

### DIFF
--- a/src/Services/ConfigService/ConfigRepository.php
+++ b/src/Services/ConfigService/ConfigRepository.php
@@ -92,9 +92,9 @@ interface ConfigRepository
     /**
      * Show / Hide system files and folders
      *
-     * @return bool
+     * @return bool|null
      */
-    public function getHiddenFiles(): bool;
+    public function getHiddenFiles(): ?bool;
 
     /**
      * Middleware

--- a/src/Services/ConfigService/DefaultConfigRepository.php
+++ b/src/Services/ConfigService/DefaultConfigRepository.php
@@ -119,9 +119,9 @@ class DefaultConfigRepository implements ConfigRepository
     /**
      * Show / Hide system files and folders
      *
-     * @return bool
+     * @return bool|null
      */
-    public function getHiddenFiles(): bool
+    public function getHiddenFiles(): ?bool
     {
         return config('file-manager.hiddenFiles');
     }


### PR DESCRIPTION
git this error after the new update:
Return value of Alexusmai\LaravelFileManager\Services\ConfigService\DefaultConfigRepository::getHiddenFiles() must be of the type bool, null returned