### PR TITLE
Fix package from most recent update. Will need new release.

### DIFF
--- a/config/file-manager.php
+++ b/config/file-manager.php
@@ -6,6 +6,12 @@ use Alexusmai\LaravelFileManager\Services\ACLService\ConfigACLRepository;
 return [
 
     /**
+     * LFM Route prefix
+     * !!! WARNING - if you change it, you should compile frontend with new prefix(baseUrl) !!!
+     */
+    'routePrefix' => 'file-manager',    
+    
+    /**
      * Set Config repository
      *
      * Default - DefaultConfigRepository get config from this file


### PR DESCRIPTION
The most recent update will break upon composer install or composer update because this is missing from the config.

Here is the error:

```
  Return value of Alexusmai\LaravelFileManager\Services\ConfigService\DefaultConfigRepository::getRoutePrefix() must be of the type string, null returned

  at vendor/alexusmai/laravel-file-manager/src/Services/ConfigService/DefaultConfigRepository.php:20

```