### PR TITLE
Name slugification added to config.

### DIFF
--- a/config/file-manager.php
+++ b/config/file-manager.php
@@ -10,14 +10,14 @@ return [
      *
      * Default - DefaultConfigRepository get config from this file
      */
-    'configRepository' => DefaultConfigRepository::class,
+    'configRepository'  => DefaultConfigRepository::class,
 
     /**
      * ACL rules repository
      *
      * Default - ConfigACLRepository (see rules in - aclRules)
      */
-    'aclRepository' => ConfigACLRepository::class,
+    'aclRepository'     => ConfigACLRepository::class,
 
     //********* Default configuration for DefaultConfigRepository **************
 
@@ -25,41 +25,41 @@ return [
      * LFM Route prefix
      * !!! WARNING - if you change it, you should compile frontend with new prefix(baseUrl) !!!
      */
-    'routePrefix' => 'file-manager',
+    'routePrefix'       => 'file-manager',
 
     /**
      * List of disk names that you want to use
      * (from config/filesystems)
      */
-    'diskList' => ['public'],
+    'diskList'          => ['public'],
 
     /**
      * Default disk for left manager
      *
      * null - auto select the first disk in the disk list
      */
-    'leftDisk' => null,
+    'leftDisk'          => null,
 
     /**
      * Default disk for right manager
      *
      * null - auto select the first disk in the disk list
      */
-    'rightDisk' => null,
+    'rightDisk'         => null,
 
     /**
      * Default path for left manager
      *
      * null - root directory
      */
-    'leftPath' => null,
+    'leftPath'          => null,
 
     /**
      * Default path for right manager
      *
      * null - root directory
      */
-    'rightPath' => null,
+    'rightPath'         => null,
 
     /**
      * Image cache ( Intervention Image Cache )
@@ -67,7 +67,7 @@ return [
      * set null, 0 - if you don't need cache (default)
      * if you want use cache - set the number of minutes for which the value should be cached
      */
-    'cache' => null,
+    'cache'             => null,
 
     /**
      * File manager modules configuration
@@ -76,7 +76,7 @@ return [
      * 2 - one file manager window with directories tree module
      * 3 - two file manager windows
      */
-    'windowsConfig' => 2,
+    'windowsConfig'     => 2,
 
     /**
      * File upload - Max file size in KB
@@ -90,12 +90,12 @@ return [
      *
      * [] - no restrictions
      */
-    'allowFileTypes' => [],
+    'allowFileTypes'    => [],
 
     /**
      * Show / Hide system files and folders
      */
-    'hiddenFiles' => true,
+    'hiddenFiles'       => true,
 
     /***************************************************************************
      * Middleware
@@ -103,21 +103,21 @@ return [
      * Add your middleware name to array -> ['web', 'auth', 'admin']
      * !!!! RESTRICT ACCESS FOR NON ADMIN USERS !!!!
      */
-    'middleware' => ['web'],
+    'middleware'        => ['web'],
 
     /***************************************************************************
      * ACL mechanism ON/OFF
      *
      * default - false(OFF)
      */
-    'acl' => false,
+    'acl'               => false,
 
     /**
      * Hide files and folders from file-manager if user doesn't have access
      *
      * ACL access level = 0
      */
-    'aclHideFromFM' => true,
+    'aclHideFromFM'     => true,
 
     /**
      * ACL strategy
@@ -126,14 +126,14 @@ return [
      *
      * whitelist - Deny anything(access - 0 - deny), that not allowed by the ACL rules list
      */
-    'aclStrategy' => 'blacklist',
+    'aclStrategy'       => 'blacklist',
 
     /**
      * ACL Rules cache
      *
      * null or value in minutes
      */
-    'aclRulesCache' => null,
+    'aclRulesCache'     => null,
 
     //********* Default configuration for DefaultConfigRepository END **********
 
@@ -156,13 +156,19 @@ return [
      *
      * access: 0 - deny, 1 - read, 2 - read/write
      */
-    'aclRules' => [
+    'aclRules'          => [
         null => [
             //['disk' => 'public', 'path' => '/', 'access' => 2],
         ],
-        1 => [
+        1    => [
             //['disk' => 'public', 'path' => 'images/arch*.jpg', 'access' => 2],
             //['disk' => 'public', 'path' => 'files/*', 'access' => 1],
         ],
     ],
+
+    /**
+     * Enable slugification of filenames of uploaded files.
+     *
+     */
+    'slugifyNames'      => false,
 ];

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,10 @@ leftDisk and leftPath is default for the file manager windows configuration - 1,
 'diskList'  => ['images', 'public'],
 ```
 
+## Normalization of uploaded file names
+
+If you expect to work with files that may have filenames that are not considered *normal* `f.e.: "DCIM_2021  - čšč& (1).jpg.jpg"` so basically any time you give the option to upload files to users, you can set `slugifyNames` to `true` and have the names ran through `Str::slug()` before saving it so you file will look something like `dcim-2021-csc-1.jpg` 
+
 ## Dynamic configuration
 
 You can create your own configuration, for example for different users or their roles.

--- a/src/Services/ConfigService/ConfigRepository.php
+++ b/src/Services/ConfigService/ConfigRepository.php
@@ -160,4 +160,13 @@ interface ConfigRepository
      * @return int|null
      */
     public function getAclRulesCache(): ?int;
+
+    /**
+     * Whether to slugify filenames
+     *
+     * boolean
+     *
+     * @return bool|null
+     */
+    public function getSlugifyNames(): ?bool;
 }

--- a/src/Services/ConfigService/DefaultConfigRepository.php
+++ b/src/Services/ConfigService/DefaultConfigRepository.php
@@ -15,7 +15,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return string
      */
-    public function getRoutePrefix(): string
+    final public function getRoutePrefix(): string
     {
         return config('file-manager.routePrefix');
     }
@@ -27,7 +27,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return array
      */
-    public function getDiskList(): array
+    final public function getDiskList(): array
     {
         return config('file-manager.diskList');
     }
@@ -39,7 +39,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return string|null
      */
-    public function getLeftDisk(): ?string
+    final public function getLeftDisk(): ?string
     {
         return config('file-manager.leftDisk');
     }
@@ -51,7 +51,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return string|null
      */
-    public function getRightDisk(): ?string
+    final public function getRightDisk(): ?string
     {
         return config('file-manager.rightDisk');
     }
@@ -63,7 +63,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return string|null
      */
-    public function getLeftPath(): ?string
+    final public function getLeftPath(): ?string
     {
         return config('file-manager.leftPath');
     }
@@ -75,7 +75,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return string|null
      */
-    public function getRightPath(): ?string
+    final public function getRightPath(): ?string
     {
         return config('file-manager.rightPath');
     }
@@ -88,7 +88,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return int|null
      */
-    public function getCache(): ?int
+    final public function getCache(): ?int
     {
         return config('file-manager.cache');
     }
@@ -102,7 +102,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return int
      */
-    public function getWindowsConfig(): int
+    final public function getWindowsConfig(): int
     {
         return config('file-manager.windowsConfig');
     }
@@ -112,7 +112,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * null - no restrictions
      */
-    public function getMaxUploadFileSize(): ?int
+    final public function getMaxUploadFileSize(): ?int
     {
         return config('file-manager.maxUploadFileSize');
     }
@@ -122,7 +122,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * [] - no restrictions
      */
-    public function getAllowFileTypes(): array
+    final public function getAllowFileTypes(): array
     {
         return config('file-manager.allowFileTypes');
     }
@@ -132,7 +132,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return bool
      */
-    public function getHiddenFiles(): bool
+    final public function getHiddenFiles(): bool
     {
         return config('file-manager.hiddenFiles');
     }
@@ -145,7 +145,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return array
      */
-    public function getMiddleware(): array
+    final public function getMiddleware(): array
     {
         return config('file-manager.middleware');
     }
@@ -157,7 +157,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return bool
      */
-    public function getAcl(): bool
+    final public function getAcl(): bool
     {
         return config('file-manager.acl');
     }
@@ -169,7 +169,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return bool
      */
-    public function getAclHideFromFM(): bool
+    final public function getAclHideFromFM(): bool
     {
         return config('file-manager.aclHideFromFM');
     }
@@ -183,7 +183,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return string
      */
-    public function getAclStrategy(): string
+    final public function getAclStrategy(): string
     {
         return config('file-manager.aclStrategy');
     }
@@ -195,7 +195,7 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return string
      */
-    public function getAclRepository(): string
+    final public function getAclRepository(): string
     {
         return config('file-manager.aclRepository');
     }
@@ -207,8 +207,20 @@ class DefaultConfigRepository implements ConfigRepository
      *
      * @return int|null
      */
-    public function getAclRulesCache(): ?int
+    final public function getAclRulesCache(): ?int
     {
         return config('file-manager.aclRulesCache');
+    }
+
+    /**
+     * Whether to slugify filenames
+     *
+     * boolean
+     *
+     * @return bool|null
+     */
+    final public function getSlugifyNames(): ?bool
+    {
+        return config('file-manager.slugifyNames', false);
     }
 }


### PR DESCRIPTION
Added option to allow slugification of names upon upload. This solves a problem of unconventional filenames such as "DCIM_2021  - čšč& (1).jpg.jpg" which will be turned into "dcim-2021-csc-1.jpg".

This is particularily usefull if you are allowing users to upload files that will be later used on a website in public way, that can be broken by filenames that have unsupported characters in them.