### PR TITLE
Bugfix: In Create/Rename file with allowed extension

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -46,27 +46,28 @@ class FileManager
         if (!config()->has('file-manager')) {
             return [
                 'result' => [
-                    'status'  => 'danger',
+                    'status' => 'danger',
                     'message' => 'noConfig',
                 ],
             ];
         }
 
         $config = [
-            'acl'           => $this->configRepository->getAcl(),
-            'leftDisk'      => $this->configRepository->getLeftDisk(),
-            'rightDisk'     => $this->configRepository->getRightDisk(),
-            'leftPath'      => $this->configRepository->getLeftPath(),
-            'rightPath'     => $this->configRepository->getRightPath(),
+            'acl' => $this->configRepository->getAcl(),
+            'leftDisk' => $this->configRepository->getLeftDisk(),
+            'rightDisk' => $this->configRepository->getRightDisk(),
+            'leftPath' => $this->configRepository->getLeftPath(),
+            'rightPath' => $this->configRepository->getRightPath(),
             'windowsConfig' => $this->configRepository->getWindowsConfig(),
-            'hiddenFiles'   => $this->configRepository->getHiddenFiles(),
+            'hiddenFiles' => $this->configRepository->getHiddenFiles(),
         ];
 
         // disk list
         foreach ($this->configRepository->getDiskList() as $disk) {
             if (array_key_exists($disk, config('filesystems.disks'))) {
                 $config['disks'][$disk] = Arr::only(
-                    config('filesystems.disks')[$disk], ['driver']
+                    config('filesystems.disks')[$disk],
+                    ['driver']
                 );
             }
         }
@@ -76,7 +77,7 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => null,
             ],
             'config' => $config,
@@ -97,12 +98,12 @@ class FileManager
         $content = $this->getContent($disk, $path);
 
         return [
-            'result'      => [
-                'status'  => 'success',
+            'result' => [
+                'status' => 'success',
                 'message' => null,
             ],
             'directories' => $content['directories'],
-            'files'       => $content['files'],
+            'files' => $content['files'],
         ];
     }
 
@@ -120,8 +121,8 @@ class FileManager
         $directories = $this->getDirectoriesTree($disk, $path);
 
         return [
-            'result'      => [
-                'status'  => 'success',
+            'result' => [
+                'status' => 'success',
                 'message' => null,
             ],
             'directories' => $directories,
@@ -149,7 +150,8 @@ class FileManager
             }
 
             // check file size
-            if ($this->configRepository->getMaxUploadFileSize()
+            if (
+                $this->configRepository->getMaxUploadFileSize()
                 && $file->getSize() / 1024 > $this->configRepository->getMaxUploadFileSize()
             ) {
                 $fileNotUploaded = true;
@@ -157,7 +159,8 @@ class FileManager
             }
 
             // check file type
-            if ($this->configRepository->getAllowFileTypes()
+            if (
+                $this->configRepository->getAllowFileTypes()
                 && !in_array(
                     $file->getClientOriginalExtension(),
                     $this->configRepository->getAllowFileTypes()
@@ -170,12 +173,12 @@ class FileManager
             $name = $file->getClientOriginalName();
             if ($this->configRepository->getSlugifyNames()) {
                 $name = Str::slug(
-                        Str::replace(
-                            '.' . $file->getClientOriginalExtension(),
-                            '',
-                            $name
-                        )
-                    ) . '.' . $file->getClientOriginalExtension();
+                    Str::replace(
+                        '.' . $file->getClientOriginalExtension(),
+                        '',
+                        $name
+                    )
+                ) . '.' . $file->getClientOriginalExtension();
             }
             // overwrite or save file
             Storage::disk($disk)->putFileAs(
@@ -188,7 +191,7 @@ class FileManager
         if ($fileNotUploaded) {
             return [
                 'result' => [
-                    'status'  => 'warning',
+                    'status' => 'warning',
                     'message' => 'notAllUploaded',
                 ],
             ];
@@ -196,7 +199,7 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'uploaded',
             ],
         ];
@@ -232,7 +235,7 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'deleted',
             ],
         ];
@@ -273,19 +276,11 @@ class FileManager
      */
     public function rename($disk, $newName, $oldName): array
     {
-        $extension = explode('.', $newName);
-        $extension = end($extension);
-        if (
-            $this->configRepository->getAllowFileTypes()
-            && !in_array(
-                $extension,
-                $this->configRepository->getAllowFileTypes()
-            )
-        ) {
+        if (!$this->AllowTypes($newName)) {
             return [
                 'result' => [
-                    'status' => 'warning',
-                    'message' => 'notAllUploaded',
+                    'status' => 'error',
+                    'message' => "Failed to rename the file because extension is not allowed",
                 ],
             ];
         }
@@ -294,7 +289,7 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'renamed',
             ],
         ];
@@ -376,10 +371,10 @@ class FileManager
     {
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => null,
             ],
-            'url'    => Storage::disk($disk)->url($path),
+            'url' => Storage::disk($disk)->url($path),
         ];
     }
 
@@ -399,7 +394,7 @@ class FileManager
         if (Storage::disk($disk)->exists($directoryName)) {
             return [
                 'result' => [
-                    'status'  => 'warning',
+                    'status' => 'warning',
                     'message' => 'dirExist',
                 ],
             ];
@@ -412,16 +407,16 @@ class FileManager
         );
 
         // add directory properties for the tree module
-        $tree          = $directoryProperties;
+        $tree = $directoryProperties;
         $tree['props'] = ['hasSubdirectories' => false];
 
         return [
-            'result'    => [
-                'status'  => 'success',
+            'result' => [
+                'status' => 'success',
                 'message' => 'dirCreated',
             ],
             'directory' => $directoryProperties,
-            'tree'      => [$tree],
+            'tree' => [$tree],
         ];
     }
 
@@ -436,12 +431,22 @@ class FileManager
      */
     public function createFile($disk, $path, $name): array
     {
+        if (!$this->AllowTypes($name)) {
+            return [
+                'result' => [
+                    'status' => 'error',
+                    'message' => "Failed to create file because extension is not allowed",
+                ],
+            ];
+        }
+
+
         $path = $this->newPath($path, $name);
 
         if (Storage::disk($disk)->exists($path)) {
             return [
                 'result' => [
-                    'status'  => 'warning',
+                    'status' => 'warning',
                     'message' => 'fileExist',
                 ],
             ];
@@ -452,10 +457,10 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'fileCreated',
             ],
-            'file'   => $fileProperties,
+            'file' => $fileProperties,
         ];
     }
 
@@ -476,15 +481,15 @@ class FileManager
             $file->getClientOriginalName()
         );
 
-        $filePath       = $this->newPath($path, $file->getClientOriginalName());
+        $filePath = $this->newPath($path, $file->getClientOriginalName());
         $fileProperties = $this->fileProperties($disk, $filePath);
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'fileUpdated',
             ],
-            'file'   => $fileProperties,
+            'file' => $fileProperties,
         ];
     }
 
@@ -506,5 +511,23 @@ class FileManager
         }
 
         return Storage::disk($disk)->response($path, $filename, ['Accept-Ranges' => 'bytes']);
+    }
+
+    private function AllowTypes($name)
+    {
+        $ext = explode('.', $name);
+        $ext = end($ext);
+
+        if (
+            $this->configRepository->getAllowFileTypes()
+            && !in_array(
+                $ext,
+                $this->configRepository->getAllowFileTypes()
+            )
+        ) {
+            return false;
+        } else {
+            return true;
+        }
     }
 }

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -273,6 +273,23 @@ class FileManager
      */
     public function rename($disk, $newName, $oldName): array
     {
+        $extension = explode('.', $newName);
+        $extension = end($extension);
+        if (
+            $this->configRepository->getAllowFileTypes()
+            && !in_array(
+                $extension,
+                $this->configRepository->getAllowFileTypes()
+            )
+        ) {
+            return [
+                'result' => [
+                    'status' => 'warning',
+                    'message' => 'notAllUploaded',
+                ],
+            ];
+        }
+
         Storage::disk($disk)->move($oldName, $newName);
 
         return [

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -46,27 +46,28 @@ class FileManager
         if (!config()->has('file-manager')) {
             return [
                 'result' => [
-                    'status'  => 'danger',
+                    'status' => 'danger',
                     'message' => 'noConfig',
                 ],
             ];
         }
 
         $config = [
-            'acl'           => $this->configRepository->getAcl(),
-            'leftDisk'      => $this->configRepository->getLeftDisk(),
-            'rightDisk'     => $this->configRepository->getRightDisk(),
-            'leftPath'      => $this->configRepository->getLeftPath(),
-            'rightPath'     => $this->configRepository->getRightPath(),
+            'acl' => $this->configRepository->getAcl(),
+            'leftDisk' => $this->configRepository->getLeftDisk(),
+            'rightDisk' => $this->configRepository->getRightDisk(),
+            'leftPath' => $this->configRepository->getLeftPath(),
+            'rightPath' => $this->configRepository->getRightPath(),
             'windowsConfig' => $this->configRepository->getWindowsConfig(),
-            'hiddenFiles'   => $this->configRepository->getHiddenFiles(),
+            'hiddenFiles' => $this->configRepository->getHiddenFiles(),
         ];
 
         // disk list
         foreach ($this->configRepository->getDiskList() as $disk) {
             if (array_key_exists($disk, config('filesystems.disks'))) {
                 $config['disks'][$disk] = Arr::only(
-                    config('filesystems.disks')[$disk], ['driver']
+                    config('filesystems.disks')[$disk],
+                    ['driver']
                 );
             }
         }
@@ -76,7 +77,7 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => null,
             ],
             'config' => $config,
@@ -97,12 +98,12 @@ class FileManager
         $content = $this->getContent($disk, $path);
 
         return [
-            'result'      => [
-                'status'  => 'success',
+            'result' => [
+                'status' => 'success',
                 'message' => null,
             ],
             'directories' => $content['directories'],
-            'files'       => $content['files'],
+            'files' => $content['files'],
         ];
     }
 
@@ -120,8 +121,8 @@ class FileManager
         $directories = $this->getDirectoriesTree($disk, $path);
 
         return [
-            'result'      => [
-                'status'  => 'success',
+            'result' => [
+                'status' => 'success',
                 'message' => null,
             ],
             'directories' => $directories,
@@ -149,7 +150,8 @@ class FileManager
             }
 
             // check file size
-            if ($this->configRepository->getMaxUploadFileSize()
+            if (
+                $this->configRepository->getMaxUploadFileSize()
                 && $file->getSize() / 1024 > $this->configRepository->getMaxUploadFileSize()
             ) {
                 $fileNotUploaded = true;
@@ -157,7 +159,8 @@ class FileManager
             }
 
             // check file type
-            if ($this->configRepository->getAllowFileTypes()
+            if (
+                $this->configRepository->getAllowFileTypes()
                 && !in_array(
                     $file->getClientOriginalExtension(),
                     $this->configRepository->getAllowFileTypes()
@@ -170,12 +173,12 @@ class FileManager
             $name = $file->getClientOriginalName();
             if ($this->configRepository->getSlugifyNames()) {
                 $name = Str::slug(
-                        Str::replace(
-                            '.' . $file->getClientOriginalExtension(),
-                            '',
-                            $name
-                        )
-                    ) . '.' . $file->getClientOriginalExtension();
+                    Str::replace(
+                        '.' . $file->getClientOriginalExtension(),
+                        '',
+                        $name
+                    )
+                ) . '.' . $file->getClientOriginalExtension();
             }
             // overwrite or save file
             Storage::disk($disk)->putFileAs(
@@ -188,7 +191,7 @@ class FileManager
         if ($fileNotUploaded) {
             return [
                 'result' => [
-                    'status'  => 'warning',
+                    'status' => 'warning',
                     'message' => 'notAllUploaded',
                 ],
             ];
@@ -196,7 +199,7 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'uploaded',
             ],
         ];
@@ -232,7 +235,7 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'deleted',
             ],
         ];
@@ -273,11 +276,28 @@ class FileManager
      */
     public function rename($disk, $newName, $oldName): array
     {
+        $extension = explode('.', $newName);
+        $extension = end($extension);
+        if (
+            $this->configRepository->getAllowFileTypes()
+            && !in_array(
+                $extension,
+                $this->configRepository->getAllowFileTypes()
+            )
+        ) {
+            return [
+                'result' => [
+                    'status' => 'warning',
+                    'message' => 'notAllUploaded',
+                ],
+            ];
+        }
+
         Storage::disk($disk)->move($oldName, $newName);
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'renamed',
             ],
         ];
@@ -359,10 +379,10 @@ class FileManager
     {
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => null,
             ],
-            'url'    => Storage::disk($disk)->url($path),
+            'url' => Storage::disk($disk)->url($path),
         ];
     }
 
@@ -382,7 +402,7 @@ class FileManager
         if (Storage::disk($disk)->exists($directoryName)) {
             return [
                 'result' => [
-                    'status'  => 'warning',
+                    'status' => 'warning',
                     'message' => 'dirExist',
                 ],
             ];
@@ -395,16 +415,16 @@ class FileManager
         );
 
         // add directory properties for the tree module
-        $tree          = $directoryProperties;
+        $tree = $directoryProperties;
         $tree['props'] = ['hasSubdirectories' => false];
 
         return [
-            'result'    => [
-                'status'  => 'success',
+            'result' => [
+                'status' => 'success',
                 'message' => 'dirCreated',
             ],
             'directory' => $directoryProperties,
-            'tree'      => [$tree],
+            'tree' => [$tree],
         ];
     }
 
@@ -424,7 +444,7 @@ class FileManager
         if (Storage::disk($disk)->exists($path)) {
             return [
                 'result' => [
-                    'status'  => 'warning',
+                    'status' => 'warning',
                     'message' => 'fileExist',
                 ],
             ];
@@ -435,10 +455,10 @@ class FileManager
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'fileCreated',
             ],
-            'file'   => $fileProperties,
+            'file' => $fileProperties,
         ];
     }
 
@@ -459,15 +479,15 @@ class FileManager
             $file->getClientOriginalName()
         );
 
-        $filePath       = $this->newPath($path, $file->getClientOriginalName());
+        $filePath = $this->newPath($path, $file->getClientOriginalName());
         $fileProperties = $this->fileProperties($disk, $filePath);
 
         return [
             'result' => [
-                'status'  => 'success',
+                'status' => 'success',
                 'message' => 'fileUpdated',
             ],
-            'file'   => $fileProperties,
+            'file' => $fileProperties,
         ];
     }
 

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -46,28 +46,27 @@ class FileManager
         if (!config()->has('file-manager')) {
             return [
                 'result' => [
-                    'status' => 'danger',
+                    'status'  => 'danger',
                     'message' => 'noConfig',
                 ],
             ];
         }
 
         $config = [
-            'acl' => $this->configRepository->getAcl(),
-            'leftDisk' => $this->configRepository->getLeftDisk(),
-            'rightDisk' => $this->configRepository->getRightDisk(),
-            'leftPath' => $this->configRepository->getLeftPath(),
-            'rightPath' => $this->configRepository->getRightPath(),
+            'acl'           => $this->configRepository->getAcl(),
+            'leftDisk'      => $this->configRepository->getLeftDisk(),
+            'rightDisk'     => $this->configRepository->getRightDisk(),
+            'leftPath'      => $this->configRepository->getLeftPath(),
+            'rightPath'     => $this->configRepository->getRightPath(),
             'windowsConfig' => $this->configRepository->getWindowsConfig(),
-            'hiddenFiles' => $this->configRepository->getHiddenFiles(),
+            'hiddenFiles'   => $this->configRepository->getHiddenFiles(),
         ];
 
         // disk list
         foreach ($this->configRepository->getDiskList() as $disk) {
             if (array_key_exists($disk, config('filesystems.disks'))) {
                 $config['disks'][$disk] = Arr::only(
-                    config('filesystems.disks')[$disk],
-                    ['driver']
+                    config('filesystems.disks')[$disk], ['driver']
                 );
             }
         }
@@ -77,7 +76,7 @@ class FileManager
 
         return [
             'result' => [
-                'status' => 'success',
+                'status'  => 'success',
                 'message' => null,
             ],
             'config' => $config,
@@ -98,12 +97,12 @@ class FileManager
         $content = $this->getContent($disk, $path);
 
         return [
-            'result' => [
-                'status' => 'success',
+            'result'      => [
+                'status'  => 'success',
                 'message' => null,
             ],
             'directories' => $content['directories'],
-            'files' => $content['files'],
+            'files'       => $content['files'],
         ];
     }
 
@@ -121,8 +120,8 @@ class FileManager
         $directories = $this->getDirectoriesTree($disk, $path);
 
         return [
-            'result' => [
-                'status' => 'success',
+            'result'      => [
+                'status'  => 'success',
                 'message' => null,
             ],
             'directories' => $directories,
@@ -150,8 +149,7 @@ class FileManager
             }
 
             // check file size
-            if (
-                $this->configRepository->getMaxUploadFileSize()
+            if ($this->configRepository->getMaxUploadFileSize()
                 && $file->getSize() / 1024 > $this->configRepository->getMaxUploadFileSize()
             ) {
                 $fileNotUploaded = true;
@@ -159,8 +157,7 @@ class FileManager
             }
 
             // check file type
-            if (
-                $this->configRepository->getAllowFileTypes()
+            if ($this->configRepository->getAllowFileTypes()
                 && !in_array(
                     $file->getClientOriginalExtension(),
                     $this->configRepository->getAllowFileTypes()
@@ -173,12 +170,12 @@ class FileManager
             $name = $file->getClientOriginalName();
             if ($this->configRepository->getSlugifyNames()) {
                 $name = Str::slug(
-                    Str::replace(
-                        '.' . $file->getClientOriginalExtension(),
-                        '',
-                        $name
-                    )
-                ) . '.' . $file->getClientOriginalExtension();
+                        Str::replace(
+                            '.' . $file->getClientOriginalExtension(),
+                            '',
+                            $name
+                        )
+                    ) . '.' . $file->getClientOriginalExtension();
             }
             // overwrite or save file
             Storage::disk($disk)->putFileAs(
@@ -191,7 +188,7 @@ class FileManager
         if ($fileNotUploaded) {
             return [
                 'result' => [
-                    'status' => 'warning',
+                    'status'  => 'warning',
                     'message' => 'notAllUploaded',
                 ],
             ];
@@ -199,7 +196,7 @@ class FileManager
 
         return [
             'result' => [
-                'status' => 'success',
+                'status'  => 'success',
                 'message' => 'uploaded',
             ],
         ];
@@ -235,7 +232,7 @@ class FileManager
 
         return [
             'result' => [
-                'status' => 'success',
+                'status'  => 'success',
                 'message' => 'deleted',
             ],
         ];
@@ -276,28 +273,11 @@ class FileManager
      */
     public function rename($disk, $newName, $oldName): array
     {
-        $extension = explode('.', $newName);
-        $extension = end($extension);
-        if (
-            $this->configRepository->getAllowFileTypes()
-            && !in_array(
-                $extension,
-                $this->configRepository->getAllowFileTypes()
-            )
-        ) {
-            return [
-                'result' => [
-                    'status' => 'warning',
-                    'message' => 'notAllUploaded',
-                ],
-            ];
-        }
-
         Storage::disk($disk)->move($oldName, $newName);
 
         return [
             'result' => [
-                'status' => 'success',
+                'status'  => 'success',
                 'message' => 'renamed',
             ],
         ];
@@ -379,10 +359,10 @@ class FileManager
     {
         return [
             'result' => [
-                'status' => 'success',
+                'status'  => 'success',
                 'message' => null,
             ],
-            'url' => Storage::disk($disk)->url($path),
+            'url'    => Storage::disk($disk)->url($path),
         ];
     }
 
@@ -402,7 +382,7 @@ class FileManager
         if (Storage::disk($disk)->exists($directoryName)) {
             return [
                 'result' => [
-                    'status' => 'warning',
+                    'status'  => 'warning',
                     'message' => 'dirExist',
                 ],
             ];
@@ -415,16 +395,16 @@ class FileManager
         );
 
         // add directory properties for the tree module
-        $tree = $directoryProperties;
+        $tree          = $directoryProperties;
         $tree['props'] = ['hasSubdirectories' => false];
 
         return [
-            'result' => [
-                'status' => 'success',
+            'result'    => [
+                'status'  => 'success',
                 'message' => 'dirCreated',
             ],
             'directory' => $directoryProperties,
-            'tree' => [$tree],
+            'tree'      => [$tree],
         ];
     }
 
@@ -444,7 +424,7 @@ class FileManager
         if (Storage::disk($disk)->exists($path)) {
             return [
                 'result' => [
-                    'status' => 'warning',
+                    'status'  => 'warning',
                     'message' => 'fileExist',
                 ],
             ];
@@ -455,10 +435,10 @@ class FileManager
 
         return [
             'result' => [
-                'status' => 'success',
+                'status'  => 'success',
                 'message' => 'fileCreated',
             ],
-            'file' => $fileProperties,
+            'file'   => $fileProperties,
         ];
     }
 
@@ -479,15 +459,15 @@ class FileManager
             $file->getClientOriginalName()
         );
 
-        $filePath = $this->newPath($path, $file->getClientOriginalName());
+        $filePath       = $this->newPath($path, $file->getClientOriginalName());
         $fileProperties = $this->fileProperties($disk, $filePath);
 
         return [
             'result' => [
-                'status' => 'success',
+                'status'  => 'success',
                 'message' => 'fileUpdated',
             ],
-            'file' => $fileProperties,
+            'file'   => $fileProperties,
         ];
     }
 


### PR DESCRIPTION
As there are allowFileTypes in the config, the upload function works fine.
But when you upload and rename a file with the disallowed extensions, the rename function does not check the file extension.