### PR TITLE
Refactor `user_id` column type from `unsignedInteger` to `unsignedBigInteger`

### DIFF
--- a/migrations/2019_02_06_174631_make_acl_rules_table.php
+++ b/migrations/2019_02_06_174631_make_acl_rules_table.php
@@ -15,7 +15,7 @@ class MakeAclRulesTable extends Migration
     {
         Schema::create('acl_rules', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('user_id')->nullable();
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->string('disk');
             $table->string('path');
             $table->tinyInteger('access');


### PR DESCRIPTION
In this pull request, the `user_id` column in the migration file has been updated from `unsignedInteger` to `unsignedBigInteger`. This change ensures better compatibility, especially when the `id` column in the `users` table is of type `unsignedBigInteger`. 

The reason for this change is to handle larger integer values and to prevent potential issues when referencing the `users` table with `BIGINT` primary keys. It also aligns with Laravel's default use of `unsignedBigInteger` for the `id` column in the `users` table, ensuring proper foreign key relationships.

This update is backward-compatible as the column remains `nullable`, and no additional changes to the database structure are required beyond this modification.
