### PR TITLE
Security Fix: Check Allowed Extension Types, Disallow Extension Types, and Disallow Mime Types

### DIFF
--- a/config/file-manager.php
+++ b/config/file-manager.php
@@ -85,6 +85,37 @@ return [
     'allowFileTypes'    => [],
 
     /**
+     * File upload - disallow these executable file types
+     *
+     * [] - default disallowed file types
+     * default: php, php3, php4, php5, phtml, js, html, htm, xhtml, shtml, jhtml, pl, py, cgi, exe
+     */
+    'disallowFileTypes'    => [],
+
+    /**
+     * File upload - disallow these executable file mimetypes
+     *
+     * [] - default disallowed mimetypes
+     * default:
+     * - text/x-php
+     * - text/html
+     * - text/javascript
+     * - application/x-javascript
+     * - text/x-javascript
+     * - application/javascript
+     * - application/x-sh
+     * - text/x-python
+     * - application/x-python
+     * - text/x-perl
+     * - application/x-perl
+     * - application/x-httpd-cgi
+     * - application/x-executable
+     * - application/x-msdownload
+     * - application/octet-stream
+     */
+    'disallowFileMimeTypes'    => [],
+
+    /**
      * Show / Hide system files and folders
      */
     'hiddenFiles'       => true,

--- a/config/file-manager.php
+++ b/config/file-manager.php
@@ -87,33 +87,48 @@ return [
     /**
      * File upload - disallow these executable file types
      *
-     * [] - default disallowed file types
-     * default: php, php3, php4, php5, phtml, js, html, htm, xhtml, shtml, jhtml, pl, py, cgi, exe
+     * [] - no restrictions
      */
-    'disallowFileTypes'    => [],
+    'disallowFileTypes'    => [
+        'php',
+        'php3',
+        'php4',
+        'php5',
+        'phtml',
+        'js',
+        'html',
+        'htm',
+        'xhtml',
+        'shtml',
+        'jhtml',
+        'pl',
+        'py',
+        'cgi',
+        'exe',
+    ],
 
     /**
      * File upload - disallow these executable file mimetypes
      *
-     * [] - default disallowed mimetypes
-     * default:
-     * - text/x-php
-     * - text/html
-     * - text/javascript
-     * - application/x-javascript
-     * - text/x-javascript
-     * - application/javascript
-     * - application/x-sh
-     * - text/x-python
-     * - application/x-python
-     * - text/x-perl
-     * - application/x-perl
-     * - application/x-httpd-cgi
-     * - application/x-executable
-     * - application/x-msdownload
-     * - application/octet-stream
+     * [] - no restrictions
      */
-    'disallowFileMimeTypes'    => [],
+    'disallowFileMimeTypes'    => [
+        'text/x-php',
+        'text/html',
+        'text/javascript',
+        'application/x-javascript',
+        'text/x-javascript',
+        'application/javascript',
+        'application/x-sh',
+        'text/x-python',
+        'application/x-python',
+        'text/x-perl',
+        'application/x-perl',
+        'application/x-httpd-cgi',
+        'application/x-executable',
+        'application/x-msdownload',
+        'application/octet-stream',
+    ],
 
     /**
      * Show / Hide system files and folders

--- a/src/Events/FilesUploaded.php
+++ b/src/Events/FilesUploaded.php
@@ -17,7 +17,7 @@ class FilesUploaded
     private $path;
 
     /**
-     * @var \Illuminate\Http\UploadedFile
+     * @var \Illuminate\Http\UploadedFile[]
      */
     private $files;
 

--- a/src/Events/FilesUploading.php
+++ b/src/Events/FilesUploading.php
@@ -17,7 +17,7 @@ class FilesUploading
     private $path;
 
     /**
-     * @var \Illuminate\Http\UploadedFile
+     * @var \Illuminate\Http\UploadedFile[]
      */
     private $files;
 

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -488,6 +488,15 @@ class FileManager
      */
     public function updateFile($disk, $path, $file): array
     {
+        if (!$this->AllowTypeFileName($file->getClientOriginalName()) || !$this->DisallowTypeFileName($file->getClientOriginalName())) {
+            return [
+                'result' => [
+                    'status'  => 'error',
+                    'message' => "Failed to create file because extension is not allowed",
+                ],
+            ];
+        }
+
         Storage::disk($disk)->putFileAs(
             $path,
             $file,

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -273,6 +273,15 @@ class FileManager
      */
     public function rename($disk, $newName, $oldName): array
     {
+        if(!$this->AllowTypes($newName)){
+            return [
+                'result' => [
+                    'status'  => 'error',
+                    'message' => "Failed to create file because extension is not allowed",
+                ],
+            ];
+        }
+
         Storage::disk($disk)->move($oldName, $newName);
 
         return [
@@ -414,6 +423,15 @@ class FileManager
      */
     public function createFile($disk, $path, $name): array
     {
+        if(!$this->AllowTypes($name)){
+            return [
+                'result' => [
+                    'status'  => 'error',
+                    'message' => "Failed to create file because extension is not allowed",
+                ],
+            ];
+        }
+
         $path = $this->newPath($path, $name);
 
         if (Storage::disk($disk)->exists($path)) {
@@ -484,5 +502,23 @@ class FileManager
         }
 
         return Storage::disk($disk)->response($path, $filename, ['Accept-Ranges' => 'bytes']);
+    }
+
+    private function AllowTypes($name)
+    {
+        $ext = explode('.', $name);
+        $ext = end($ext);
+
+        if (
+            $this->configRepository->getAllowFileTypes()
+            && !in_array(
+                $ext,
+                $this->configRepository->getAllowFileTypes()
+            )
+        ) {
+            return false;
+        } else {
+            return true;
+        }
     }
 }

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -167,15 +167,37 @@ class FileManager
                 continue;
             }
 
+            // check file disallow type
+            if ($this->configRepository->getDisallowFileTypes()
+                && in_array(
+                    $file->getClientOriginalExtension(),
+                    $this->configRepository->getDisallowFileTypes()
+                )
+            ) {
+                $fileNotUploaded = true;
+                continue;
+            }
+
+            // check file mime type
+            if ($this->configRepository->getDisallowFileMimeTypes()
+                && in_array(
+                    $file->getMimeType(),
+                    $this->configRepository->getDisallowFileMimeTypes()
+                )
+            ) {
+                $fileNotUploaded = true;
+                continue;
+            }
+
             $name = $file->getClientOriginalName();
             if ($this->configRepository->getSlugifyNames()) {
                 $name = Str::slug(
-                        Str::replace(
-                            '.' . $file->getClientOriginalExtension(),
-                            '',
-                            $name
-                        )
-                    ) . '.' . $file->getClientOriginalExtension();
+                    Str::replace(
+                        '.' . $file->getClientOriginalExtension(),
+                        '',
+                        $name
+                    )
+                ) . '.' . $file->getClientOriginalExtension();
             }
             // overwrite or save file
             Storage::disk($disk)->putFileAs(
@@ -273,7 +295,7 @@ class FileManager
      */
     public function rename($disk, $newName, $oldName): array
     {
-        if(!$this->AllowTypes($newName)){
+        if (!$this->AllowTypeFileName($newName) || !$this->DisallowTypeFileName($newName)) {
             return [
                 'result' => [
                     'status'  => 'error',
@@ -423,7 +445,7 @@ class FileManager
      */
     public function createFile($disk, $path, $name): array
     {
-        if(!$this->AllowTypes($name)){
+        if (!$this->AllowTypeFileName($name) || !$this->DisallowTypeFileName($name)) {
             return [
                 'result' => [
                     'status'  => 'error',
@@ -504,7 +526,7 @@ class FileManager
         return Storage::disk($disk)->response($path, $filename, ['Accept-Ranges' => 'bytes']);
     }
 
-    private function AllowTypes($name)
+    private function AllowTypeFileName($name)
     {
         $ext = explode('.', $name);
         $ext = end($ext);
@@ -514,6 +536,24 @@ class FileManager
             && !in_array(
                 $ext,
                 $this->configRepository->getAllowFileTypes()
+            )
+        ) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private function DisallowTypeFileName($name)
+    {
+        $ext = explode('.', $name);
+        $ext = end($ext);
+
+        if (
+            $this->configRepository->getDisallowFileTypes()
+            && in_array(
+                $ext,
+                $this->configRepository->getDisallowFileTypes()
             )
         ) {
             return false;

--- a/src/Services/ConfigService/ConfigRepository.php
+++ b/src/Services/ConfigService/ConfigRepository.php
@@ -88,6 +88,20 @@ interface ConfigRepository
     public function getAllowFileTypes(): array;
 
     /**
+     * File upload - disallow these executable file types
+     *
+     * [] - no restrictions
+     */
+    public function getDisallowFileTypes(): array;
+
+    /**
+     * File upload - disallow these executable file mimetypes
+     *
+     * [] - no restrictions
+     */
+    public function getDisallowFileMimeTypes(): array;
+
+    /**
      * Show / Hide system files and folders
      *
      * @return bool

--- a/src/Services/ConfigService/DefaultConfigRepository.php
+++ b/src/Services/ConfigService/DefaultConfigRepository.php
@@ -115,6 +115,58 @@ class DefaultConfigRepository implements ConfigRepository
     }
 
     /**
+     * File upload - disallow these executable file types
+     *
+     * [] - no restrictions
+     */
+    final public function getDisallowFileTypes(): array
+    {
+        return config('file-manager.disallowFileTypes', [
+            'php',
+            'php3',
+            'php4',
+            'php5',
+            'phtml',
+            'js',
+            'html',
+            'htm',
+            'xhtml',
+            'shtml',
+            'jhtml',
+            'pl',
+            'py',
+            'cgi',
+            'exe',
+        ]);
+    }
+
+    /**
+     * File upload - disallow these executable file mimetypes
+     *
+     * [] - no restrictions
+     */
+    final public function getDisallowFileMimeTypes(): array
+    {
+        return config('file-manager.disallowFileMimeTypes', [
+            'text/x-php',
+            'text/html',
+            'text/javascript',
+            'application/x-javascript',
+            'text/x-javascript',
+            'application/javascript',
+            'application/x-sh',
+            'text/x-python',
+            'application/x-python',
+            'text/x-perl',
+            'application/x-perl',
+            'application/x-httpd-cgi',
+            'application/x-executable',
+            'application/x-msdownload',
+            'application/octet-stream',
+        ]);
+    }
+
+    /**
      * Show / Hide system files and folders
      *
      * @return bool


### PR DESCRIPTION
This pull request introduces comprehensive restrictions on disallowed file types and MIME types for uploads and archive extraction, significantly improving the security of the file manager. The changes ensure that potentially dangerous files (such as PHP scripts or executables) cannot be uploaded, created, renamed, or extracted from ZIP archives. Additionally, the configuration and service layers have been updated to support these new restrictions.

**Security enhancements for file uploads and archive extraction:**

* Added `disallowFileTypes` and `disallowFileMimeTypes` configuration options in `file-manager.php` to specify restricted file extensions and MIME types.
* Updated the `ConfigRepository` interface and its default implementation to provide access to the new disallow lists, with sensible defaults for common executable/script types. [[1]](diffhunk://#diff-7421be20c048ec9b9e540f5015586539bf98b2063e41a4569a60413f4c6849b9R90-R103) [[2]](diffhunk://#diff-70fdce360f86be3b9b5d70cd0e26210b7cb51dc2973d54cb4d437e6673e87212R117-R168)
* Modified the file upload logic in `FileManager.php` to block files with disallowed extensions or MIME types from being uploaded.
* Enforced extension checks when creating, renaming, or updating files, preventing creation or renaming to disallowed types. [[1]](diffhunk://#diff-9c1c66c720f3ffca963d960c2725f1f7258e136c00565d0184faff287824ab48R298-R306) [[2]](diffhunk://#diff-9c1c66c720f3ffca963d960c2725f1f7258e136c00565d0184faff287824ab48R448-R456) [[3]](diffhunk://#diff-9c1c66c720f3ffca963d960c2725f1f7258e136c00565d0184faff287824ab48R491-R499) [[4]](diffhunk://#diff-9c1c66c720f3ffca963d960c2725f1f7258e136c00565d0184faff287824ab48R537-R572)

**ZIP archive extraction hardening:**

* Updated the `Zip` service to check extracted files' extensions and MIME types against the disallow lists, skipping extraction of any that match. The service now requires `ConfigRepository` as a dependency. [[1]](diffhunk://#diff-7783bc9015fac2aafbe81f0a2db039500952985b7276cfcdf0eb3b4f5858b944R9) [[2]](diffhunk://#diff-7783bc9015fac2aafbe81f0a2db039500952985b7276cfcdf0eb3b4f5858b944R19-R34) [[3]](diffhunk://#diff-7783bc9015fac2aafbe81f0a2db039500952985b7276cfcdf0eb3b4f5858b944L143-L159)

**Other improvements:**

* Updated PHPDoc annotations in `FilesUploading` and `FilesUploaded` event classes to clarify that the `$files` property is an array of uploaded files. [[1]](diffhunk://#diff-c5aba1235019d69c3356208a0aaa4e0ae3229b9b12668fa0402c51179e32b559L20-R20) [[2]](diffhunk://#diff-93b44cfdb29669c591ec9aee833faaca3f8edca433a850255ea461e105549b47L20-R20)