### PR TITLE
fix: locales like 'pt_BR' 'fr_BE' will work when send to the frontend

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -72,7 +72,7 @@ class FileManager
         }
 
         // get language
-        $config['lang'] = app()->getLocale();
+        $config['lang'] = str_replace('_','-',app()->getLocale());
 
         return [
             'result' => [


### PR DESCRIPTION
I recently had a problem using laravel-file-maneger. When I opened the manager it didnt show any file, only folder. Trying to find the problem I found the following error in the frontend:
![image](https://github.com/user-attachments/assets/7337af3a-fae0-4d45-8bb9-a6c211b676df)

So looking more deep I found the problem is the same as here: https://github.com/formatjs/formatjs/discussions/2440

Basically, if you use intl for internationalization, it wont work if it couldnt find a valid lang for the case, so, 'pt_BR' is a invalid lang, but 'pt-BR' is valid.

_But why dont I change that in the app.php config?_

Because php use the oposite 😃.
You can see here: https://www.php.net/manual/en/intlcalendar.getavailablelocales.php

So, this PR only replace all `_` in a locale with `-`. I checked and any Intl locales use '_' in their names.