### PR TITLE
Support S3 rename/cut operations

### DIFF
--- a/src/Services/TransferService/S3CompatibleTransfer.php
+++ b/src/Services/TransferService/S3CompatibleTransfer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Alexusmai\LaravelFileManager\Services\TransferService;
+
+use Alexusmai\LaravelFileManager\Traits\MoveFolderTrait;
+use Storage;
+
+class S3CompatibleTransfer extends LocalTransfer
+{
+    use MoveFolderTrait;
+
+    protected function cut()
+    {
+        $disk = Storage::disk($this->disk);
+
+        // files
+        foreach ($this->clipboard['files'] as $file) {
+            $disk->move(
+                $file,
+                $this->renamePath($file, $this->path)
+            );
+        }
+
+        // directories
+        foreach ($this->clipboard['directories'] as $oldPath) {
+            $this->moveFolder($disk, $oldPath, $this->renamePath($oldPath, $this->path));
+        }
+    }
+}

--- a/src/Services/TransferService/TransferFactory.php
+++ b/src/Services/TransferService/TransferFactory.php
@@ -2,6 +2,8 @@
 
 namespace Alexusmai\LaravelFileManager\Services\TransferService;
 
+use Alexusmai\LaravelFileManager\FileManager;
+
 class TransferFactory
 {
     /**
@@ -9,12 +11,16 @@ class TransferFactory
      * @param $path
      * @param $clipboard
      *
-     * @return ExternalTransfer|LocalTransfer
+     * @return ExternalTransfer|S3CompatibleTransfer|LocalTransfer
      */
     public static function build($disk, $path, $clipboard)
     {
         if ($disk !== $clipboard['disk']) {
             return new ExternalTransfer($disk, $path, $clipboard);
+        }
+
+        if (FileManager::getDiskDriver($disk) === 's3') {
+            return new S3CompatibleTransfer($disk, $path, $clipboard);
         }
 
         return new LocalTransfer($disk, $path, $clipboard);

--- a/src/Traits/MoveFolderTrait.php
+++ b/src/Traits/MoveFolderTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Alexusmai\LaravelFileManager\Traits;
+
+use Illuminate\Filesystem\FilesystemAdapter;
+use Storage;
+
+trait MoveFolderTrait
+{
+
+    /**
+     * S3 and other remote disks often do not support move() for folders.
+     * This method adds a way to move a folder by a simple process of making
+     * the new folder and moving the old contents over, then removing the
+     * old folder.
+     *
+     * @param string|FilesystemAdapter $disk The disk to perform the operation on.
+     * @param string $oldPath
+     * @param string $newPath
+     */
+    protected function moveFolder(string|FilesystemAdapter $disk, string $oldPath, string $newPath): void
+    {
+        $storage = $disk instanceof FilesystemAdapter
+            ? $disk
+            : Storage::disk($disk);
+
+        // If we're renaming a folder, we have to recreate the whole
+        // structure...
+        $storage->makeDirectory($newPath);
+
+        // Ensure all subfolders are built (including empty).
+        foreach ($storage->allDirectories($oldPath) as $path) {
+            $storage->makeDirectory(str_replace($oldPath, $newPath, $path));
+        }
+
+        // Now move all files over...
+        foreach ($storage->allFiles($oldPath) as $file) {
+            $storage->move($file, str_replace($oldPath, $newPath, $file));
+        }
+
+        // And finish by cleaning up the old folders.
+        $storage->deleteDirectory($oldPath);
+    }
+
+}


### PR DESCRIPTION
When using your library, we observed that on S3 the rename/cut operations are broken. This appears to be caused by the assumption that the default Flysystem `rename()` operation is well supported for folders. However, on S3 folders do not exist. Instead, it's a flat file system that uses "tags" to handle folders--and does not provide any folder move/rename function.

To support rename/move operations on S3, I've added a trait to provide the `moveFolder()` action. It's flow is very simple: create the new folder; move the old folder's contents there; and delete the old folder. Because `rename()` on local and supported drivers is much more efficient, I also added some logic to detect when the disk is S3 for these specific operations. I was also careful to add support for "scoped" file systems (which may be scoped within S3).

It's possible that other non-S3 compatible drivers are affected by this use case.

This contribution was sponsored by our client, [TRB+ Associates](https://trbplus.com/).