### PR TITLE
Harden file upload handling against executable files

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,12 @@ leftDisk and leftPath is default for the file manager windows configuration - 1,
 
 If you expect to work with files that may have filenames that are not considered *normal* `f.e.: "DCIM_2021  - čšč& (1).jpg.jpg"` so basically any time you give the option to upload files to users, you can set `slugifyNames` to `true` and have the names ran through `Str::slug()` before saving it so you file will look something like `dcim-2021-csc-1.jpg` 
 
+## Upload security
+
+Known executable file extensions and web server configuration files are always rejected.
+Configure `allowFileTypes` and `maxUploadFileSize` for your application as additional
+restrictions. Store user uploads on a disk where the web server does not execute scripts.
+
 ## Dynamic configuration
 
 You can create your own configuration, for example for different users or their roles.

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -7,6 +7,7 @@ use Alexusmai\LaravelFileManager\Services\ConfigService\ConfigRepository;
 use Alexusmai\LaravelFileManager\Services\TransferService\TransferFactory;
 use Alexusmai\LaravelFileManager\Traits\CheckTrait;
 use Alexusmai\LaravelFileManager\Traits\ContentTrait;
+use Alexusmai\LaravelFileManager\Traits\FileSecurityTrait;
 use Alexusmai\LaravelFileManager\Traits\PathTrait;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Http\Response;
@@ -19,7 +20,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class FileManager
 {
-    use PathTrait, ContentTrait, CheckTrait;
+    use PathTrait, ContentTrait, CheckTrait, FileSecurityTrait;
 
     /**
      * @var ConfigRepository
@@ -148,21 +149,7 @@ class FileManager
                 continue;
             }
 
-            // check file size
-            if ($this->configRepository->getMaxUploadFileSize()
-                && $file->getSize() / 1024 > $this->configRepository->getMaxUploadFileSize()
-            ) {
-                $fileNotUploaded = true;
-                continue;
-            }
-
-            // check file type
-            if ($this->configRepository->getAllowFileTypes()
-                && !in_array(
-                    $file->getClientOriginalExtension(),
-                    $this->configRepository->getAllowFileTypes()
-                )
-            ) {
+            if (!$this->isUploadAllowed($file)) {
                 $fileNotUploaded = true;
                 continue;
             }
@@ -273,6 +260,10 @@ class FileManager
      */
     public function rename($disk, $newName, $oldName): array
     {
+        if ($this->hasDangerousFilename($newName)) {
+            return $this->dangerousFileTypeMessage();
+        }
+
         Storage::disk($disk)->move($oldName, $newName);
 
         return [
@@ -414,6 +405,10 @@ class FileManager
      */
     public function createFile($disk, $path, $name): array
     {
+        if ($this->hasDangerousFilename($name)) {
+            return $this->dangerousFileTypeMessage();
+        }
+
         $path = $this->newPath($path, $name);
 
         if (Storage::disk($disk)->exists($path)) {
@@ -448,6 +443,10 @@ class FileManager
      */
     public function updateFile($disk, $path, $file): array
     {
+        if (!$this->isUploadAllowed($file)) {
+            return $this->fileNotUploadedMessage();
+        }
+
         Storage::disk($disk)->putFileAs(
             $path,
             $file,
@@ -463,6 +462,52 @@ class FileManager
                 'message' => 'fileUpdated',
             ],
             'file'   => $fileProperties,
+        ];
+    }
+
+    protected function isUploadAllowed($file): bool
+    {
+        if ($this->hasDangerousFilename($file->getClientOriginalName())
+            || $this->hasDangerousMimeType($file->getMimeType())
+        ) {
+            return false;
+        }
+
+        if ($this->configRepository->getMaxUploadFileSize()
+            && $file->getSize() / 1024 > $this->configRepository->getMaxUploadFileSize()
+        ) {
+            return false;
+        }
+
+        $allowedExtensions = array_map(
+            'strtolower',
+            $this->configRepository->getAllowFileTypes()
+        );
+
+        return !$allowedExtensions || in_array(
+            strtolower($file->getClientOriginalExtension()),
+            $allowedExtensions,
+            true
+        );
+    }
+
+    protected function dangerousFileTypeMessage(): array
+    {
+        return [
+            'result' => [
+                'status'  => 'warning',
+                'message' => 'dangerousFileType',
+            ],
+        ];
+    }
+
+    protected function fileNotUploadedMessage(): array
+    {
+        return [
+            'result' => [
+                'status'  => 'warning',
+                'message' => 'notAllUploaded',
+            ],
         ];
     }
 

--- a/src/Services/TransferService/Transfer.php
+++ b/src/Services/TransferService/Transfer.php
@@ -2,8 +2,13 @@
 
 namespace Alexusmai\LaravelFileManager\Services\TransferService;
 
+use Alexusmai\LaravelFileManager\Traits\FileSecurityTrait;
+use Illuminate\Support\Facades\Storage;
+
 abstract class Transfer
 {
+    use FileSecurityTrait;
+
     public $disk;
     public $path;
     public $clipboard;
@@ -29,6 +34,15 @@ abstract class Transfer
      */
     public function filesTransfer(): array
     {
+        if ($this->containsDangerousFile()) {
+            return [
+                'result' => [
+                    'status'  => 'warning',
+                    'message' => 'dangerousFileType',
+                ],
+            ];
+        }
+
         try {
             // determine the type of operation
             if ($this->clipboard['type'] === 'copy') {
@@ -56,4 +70,23 @@ abstract class Transfer
     abstract protected function copy();
 
     abstract protected function cut();
+
+    protected function containsDangerousFile(): bool
+    {
+        foreach ($this->clipboard['files'] as $file) {
+            if ($this->hasDangerousFilename($file)) {
+                return true;
+            }
+        }
+
+        foreach ($this->clipboard['directories'] as $directory) {
+            foreach (Storage::disk($this->clipboard['disk'])->allFiles($directory) as $file) {
+                if ($this->hasDangerousFilename($file)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Services/Zip.php
+++ b/src/Services/Zip.php
@@ -6,6 +6,7 @@ use Alexusmai\LaravelFileManager\Events\UnzipCreated;
 use Alexusmai\LaravelFileManager\Events\UnzipFailed;
 use Alexusmai\LaravelFileManager\Events\ZipCreated;
 use Alexusmai\LaravelFileManager\Events\ZipFailed;
+use Alexusmai\LaravelFileManager\Traits\FileSecurityTrait;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use RecursiveIteratorIterator;
@@ -14,6 +15,8 @@ use ZipArchive;
 
 class Zip
 {
+    use FileSecurityTrait;
+
     protected $zip;
     protected $request;
     //protected $pathPrefix;
@@ -96,6 +99,18 @@ class Zip
     {
         // elements list
         $elements = $this->request->input('elements');
+        $archiveName = (string) $this->request->input('name');
+
+        if ($this->hasPathTraversal($archiveName)
+            || str_contains($archiveName, '/')
+            || str_contains($archiveName, '\\')
+            || str_contains($archiveName, ':')
+            || $this->hasDangerousFilename($archiveName)
+        ) {
+            event(new ZipFailed($this->request));
+
+            return false;
+        }
 
         // Check files for traversal
         if (isset($elements['files']) && is_array($elements['files'])) {
@@ -161,12 +176,19 @@ class Zip
         // extract to new folder
         $folder = $this->request->input('folder');
 
-        if ($folder && (strpos($folder, '..') !== false || strpos($folder, '://') !== false)) {
+        if ($folder && $this->hasPathTraversal($folder)) {
             event(new UnzipFailed($this->request));
             return false;
         }
 
         if ($this->zip->open($zipPath) === true) {
+            if ($this->containsUnsafeEntry()) {
+                $this->zip->close();
+                event(new UnzipFailed($this->request));
+
+                return false;
+            }
+
             $this->zip->extractTo($folder ? $rootPath.'/'.$folder : $rootPath);
             $this->zip->close();
 
@@ -176,6 +198,26 @@ class Zip
         }
 
         event(new UnzipFailed($this->request));
+
+        return false;
+    }
+
+    protected function containsUnsafeEntry(): bool
+    {
+        for ($index = 0; $index < $this->zip->numFiles; $index++) {
+            $entry = $this->zip->getNameIndex($index);
+
+            if ($entry === false) {
+                return true;
+            }
+
+            $entry = str_replace('\\', '/', $entry);
+            if ($this->hasPathTraversal($entry)
+                || (!str_ends_with($entry, '/') && $this->hasDangerousFilename($entry))
+            ) {
+                return true;
+            }
+        }
 
         return false;
     }

--- a/src/Traits/FileSecurityTrait.php
+++ b/src/Traits/FileSecurityTrait.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Alexusmai\LaravelFileManager\Traits;
+
+trait FileSecurityTrait
+{
+    /**
+     * Extensions that may be executed by common web server configurations.
+     *
+     * @var array<int, string>
+     */
+    protected array $dangerousExtensions = [
+        'asp',
+        'aspx',
+        'cgi',
+        'inc',
+        'jsp',
+        'pgif',
+        'phar',
+        'php',
+        'php2',
+        'php3',
+        'php4',
+        'php5',
+        'php6',
+        'php7',
+        'php8',
+        'pht',
+        'phtm',
+        'phtml',
+        'phps',
+        'pl',
+        'py',
+        'shtml',
+    ];
+
+    /**
+     * Files that can alter how a web server handles uploaded content.
+     *
+     * @var array<int, string>
+     */
+    protected array $dangerousFilenames = [
+        '.htaccess',
+        '.user.ini',
+        'web.config',
+    ];
+
+    /**
+     * MIME types that identify executable PHP content.
+     *
+     * @var array<int, string>
+     */
+    protected array $dangerousMimeTypes = [
+        'application/x-httpd-php',
+        'application/x-php',
+        'text/x-php',
+    ];
+
+    protected function hasDangerousFilename(string $path): bool
+    {
+        $filename = strtolower(basename(str_replace('\\', '/', $path)));
+        $filename = explode(':', $filename, 2)[0];
+        $filename = rtrim($filename, ". \t\n\r\0\x0B");
+
+        if (in_array($filename, $this->dangerousFilenames, true)) {
+            return true;
+        }
+
+        return (bool) array_intersect(
+            explode('.', $filename),
+            $this->dangerousExtensions
+        );
+    }
+
+    protected function hasPathTraversal(string $path): bool
+    {
+        $path = str_replace('\\', '/', $path);
+
+        return str_starts_with($path, '/')
+            || preg_match('/^[a-zA-Z]:\//', $path)
+            || in_array('..', explode('/', $path), true);
+    }
+
+    protected function hasDangerousMimeType(?string $mimeType): bool
+    {
+        return $mimeType !== null
+            && in_array(strtolower($mimeType), $this->dangerousMimeTypes, true);
+    }
+}


### PR DESCRIPTION
## Summary

- reject known executable file extensions and web server configuration files
- apply upload validation consistently to upload and update operations
- prevent unsafe renames and file creation
- block unsafe files during copy and cut operations
- reject executable files and traversal paths during ZIP extraction
- document upload storage security requirements
